### PR TITLE
sobre las preferencias

### DIFF
--- a/core/daos/preferences.py
+++ b/core/daos/preferences.py
@@ -15,7 +15,7 @@ class Preferences():
     
     def __init__(self, account_id):
         self.data = dict()
-        self.data['account_id'] = account_id
+        self.data['account.id'] = account_id
         self.memcached = settings.MEMCACHED_ENGINE_END_POINT
         self.engine_cache = False
         if self.memcached:
@@ -40,7 +40,7 @@ class Preferences():
                 # then try from database
                 try:
                     self.data[key] = Preference.objects.get_value_by_account_id_and_key(
-                        self.data['account_id'],
+                        self.data['account.id'],
                         key=key
                     )
                     if settings.DEBUG: logger.info('Get from DB %s=%s' % (key, self.data[key]))
@@ -52,7 +52,7 @@ class Preferences():
         return self.data[key]
 
     def load(self, keys):
-        preferences = Preference.objects.filter(key__in=keys, account_id=self.data['account_id']).values('key', 'value')
+        preferences = Preference.objects.filter(key__in=keys, account_id=self.data['account.id']).values('key', 'value')
         for preference in preferences:
             key = preference['key']
             self.data[key.replace('_', '.')] = preference['value']
@@ -69,7 +69,7 @@ class Preferences():
         self.data[key] = value
 
         if value:
-            pref, is_new = Preference.objects.get_or_create(account_id = self.data['account_id'], key = key, defaults={'value': value})
+            pref, is_new = Preference.objects.get_or_create(account_id = self.data['account.id'], key = key, defaults={'value': value})
             self.save_on_cache(str(key), value)
             if not is_new:
                 pref.value = value
@@ -77,7 +77,7 @@ class Preferences():
             return pref
         else:
             try:
-                Preference.objects.get(account_id = self.data['account_id'], key = key).delete()
+                Preference.objects.get(account_id = self.data['account.id'], key = key).delete()
             except Preference.DoesNotExist:
                 pass
             return None
@@ -89,7 +89,7 @@ class Preferences():
     def get_from_cache(self, key):
         key = key.replace('_', '.')
         if self.engine_cache:
-            key = 'preference_%s_%s' % (str(self.data['account_id']), key)
+            key = 'preference_%s_%s' % (str(self.data['account.id']), key)
             value = self.engine_cache.get(str(key))
             logger = logging.getLogger(__name__)
             if settings.DEBUG: logger.info('Get from cache %s=%s' % (key, value))
@@ -102,7 +102,7 @@ class Preferences():
         if self.engine_cache:
             logger = logging.getLogger(__name__)
             try:
-                key = 'preference_%s_%s' % (str(self.data['account_id']), key)
+                key = 'preference_%s_%s' % (str(self.data['account.id']), key)
                 self.engine_cache.set(key, value, settings.MEMCACHED_DEFAULT_TTL)    
                 if settings.DEBUG: logger.info('Save on cache %s=%s' % (key, value))
                 return True

--- a/core/daos/preferences.py
+++ b/core/daos/preferences.py
@@ -8,6 +8,11 @@ from core.models import Preference
 
 
 class Preferences():
+    """ 
+    account's preferences. 
+    In database always use '.' as separator, never '_'
+    """ 
+    
     def __init__(self, account_id):
         self.data = dict()
         self.data['account_id'] = account_id
@@ -18,14 +23,17 @@ class Preferences():
                 self.engine_cache = memcache.Client(self.memcached, debug=0)
             except:
                 #TODO raise an memcache error (?)
-                # 'No memcached client could be created.')
-                pass
+                logger = logging.getLogger(__name__)
+                logger.error('No memcached client could be created')
 
     def __getitem__(self, key):
         """ get item from internal data, or cache or readed from database """
+        key = key.replace('_', '.')
+        
         if not self.data.has_key(key):
             # try from memcache
             value = self.get_from_cache(key)
+            logger = logging.getLogger(__name__)
             if value is not None:
                 self.data[key] = value
             else:
@@ -33,50 +41,72 @@ class Preferences():
                 try:
                     self.data[key] = Preference.objects.get_value_by_account_id_and_key(
                         self.data['account_id'],
-                        key=key.replace('_', '.')
+                        key=key
                     )
+                    if settings.DEBUG: logger.info('Get from DB %s=%s' % (key, self.data[key]))
                 except Preference.DoesNotExist:
                     self.data[key] = ''
                 else:
-                    self.save_on_cache(key, self.data[key])
+                    self.save_on_cache(str(key), self.data[key])
 
         return self.data[key]
 
     def load(self, keys):
-        preferences = Preference.objects.filter(key__in=keys, account=self.data['account_id']).values('key', 'value')
+        preferences = Preference.objects.filter(key__in=keys, account_id=self.data['account_id']).values('key', 'value')
         for preference in preferences:
             key = preference['key']
-            self.data[key.replace('.', '_')] = preference['value']
+            self.data[key.replace('_', '.')] = preference['value']
             keys.remove(key)
 
         for key in keys:
-            self.data[key.replace('.', '_')] = ''
+            self.data[key.replace('_', '.')] = ''
 
     def keys(self):
         return self.data.keys()
 
     def __setitem__(self, key, value):
+        key = key.replace('_', '.')
         self.data[key] = value
-        self.save_on_cache(str(key), value)
+
+        if value:
+            pref, is_new = Preference.objects.get_or_create(account_id = self.data['account_id'], key = key, defaults={'value': value})
+            self.save_on_cache(str(key), value)
+            if not is_new:
+                pref.value = value
+                pref.save()
+            return pref
+        else:
+            try:
+                Preference.objects.get(account_id = self.data['account_id'], key = key).delete()
+            except Preference.DoesNotExist:
+                pass
+            return None
 
     def load_all(self):
         keys = [pref[0] for pref in choices.ACCOUNT_PREFERENCES_AVAILABLE_KEYS]
         self.load(keys)
 
     def get_from_cache(self, key):
+        key = key.replace('_', '.')
         if self.engine_cache:
             key = 'preference_%s_%s' % (str(self.data['account_id']), key)
-            return self.engine_cache.get(str(key))
+            value = self.engine_cache.get(str(key))
+            logger = logging.getLogger(__name__)
+            if settings.DEBUG: logger.info('Get from cache %s=%s' % (key, value))
+            return value
 
         return None
 
     def save_on_cache(self, key, value):
+        key = key.replace('_', '.')
         if self.engine_cache:
+            logger = logging.getLogger(__name__)
             try:
                 key = 'preference_%s_%s' % (str(self.data['account_id']), key)
-                self.engine_cache.set(key, value, settings.MEMCACHED_DEFAULT_TTL)
+                self.engine_cache.set(key, value, settings.MEMCACHED_DEFAULT_TTL)    
+                if settings.DEBUG: logger.info('Save on cache %s=%s' % (key, value))
                 return True
-            except:
-                pass
-
+            except Exception, e:
+                logger.error('No se grabo la preferencia (%s) en cache: %s' % (str(key), str(e)))
+                
         return False

--- a/core/models.py
+++ b/core/models.py
@@ -134,24 +134,17 @@ class Account(models.Model):
         return self.name
 
     def get_preference(self, key):
-        try:
-            return Preference.objects.values('value').get(account = self, key = key)['value']
-        except Preference.DoesNotExist:
-            return ''
-
+        """ use the preferences class with cache """
+        from core.daos.preferences import Preferences
+        p = Preferences(account_id=self.id)
+        return p[key]
+        
     def set_preference(self, key, value):
-        if value:
-            pref, is_new = Preference.objects.get_or_create(account = self, key = key, defaults={'value': value})
-            if not is_new:
-                pref.value = value
-                pref.save()
-            return pref
-        else:
-            try:
-                Preference.objects.get(account = self, key = key).delete()
-            except Preference.DoesNotExist:
-                pass
-            return None
+        """ use the preferences class with cache """
+        from core.daos.preferences import Preferences
+        p = Preferences(account_id=self.id)
+        p[key]=value
+        return p[key]
 
     def get_preferences(self):
         from core.daos.preferences import Preferences

--- a/workspace/personalizeHome/views.py
+++ b/workspace/personalizeHome/views.py
@@ -19,7 +19,8 @@ from workspace.personalizeHome.managers import ThemeFinder
 @csrf_exempt
 def load(request):
     auth_manager = request.auth_manager
-    preference = request.preferences
+    account = auth_manager.get_account()
+    preference = account.get_preferences()
     stats = request.stats #TODO this must be loaded at context_procesor but it's not working 
     jsonContent = preference["account_home"]
     home_tab = True

--- a/workspace/personalizeHome/views.py
+++ b/workspace/personalizeHome/views.py
@@ -39,16 +39,16 @@ def save(request):
         preferences = account.get_preferences()
         if jsonObj['type'] == 'save':
             if jsonObj['theme'] is None:
-                account.set_preference('account.has.home', False)
+                preferences['account.has.home'] = False
             else:
-                account.set_preference('account.has.home', True)
+                preferences['account.has.home'] = True
             account.set_preference('account.home', jsonContent)
             return HttpResponse(json.dumps({
                 'status': 'ok',
                 'messages': [ugettext('APP-PREFERENCES-SAVESUCCESSFULLY-TEXT')]}), content_type='application/json')
         else:
             previewHome = 'http://'+preferences['account_domain']+'/home?preview=true'
-            account.set_preference('account.preview', jsonContent)
+            preferences['account.preview'] = jsonContent
             return HttpResponse(json.dumps({'preview_home':previewHome}), content_type='application/json')
 
 


### PR DESCRIPTION
Se pasa a usar la clase *Preferences* desde *Accounts* para tomar los datos en el cache que usa la primera.
Se estandariza el uso de separadores de termino en el *punto* como reemplazo a los guiones bajos al grabar a disco y cache.

Se valida que funciona ok en la rama para el ticket https://www.pivotaltracker.com/n/projects/1092842/stories/102475386
