### PR TITLE
Pasar microsites y api a https 

### DIFF
--- a/core/choices.py
+++ b/core/choices.py
@@ -420,7 +420,7 @@ ACCOUNT_PREFERENCES_AVAILABLE_KEYS = (
     ,('account.search.tips', 'account.search.tips')
 
     # TODO: Mover al plugin
-    ,('account.featured.dashboards', 'account.featured.dashboards')
+    ,('account.featured.dashboards', 'account.featured.dashboards'),
 
     # https for microsites or api
     ('account.microsite.https', 'account.microsite.https'),

--- a/core/choices.py
+++ b/core/choices.py
@@ -421,6 +421,10 @@ ACCOUNT_PREFERENCES_AVAILABLE_KEYS = (
 
     # TODO: Mover al plugin
     ,('account.featured.dashboards', 'account.featured.dashboards')
+
+    # https for microsites or api
+    ('account.microsite.https', 'account.microsite.https'),
+    ('account.api.https', 'account.api.https'),
 )
 
 API_APPLICATION_TYPE_CHOICES = (

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -13,8 +13,17 @@ def request_context(request):
         'DOMAINS': settings.DOMAINS,
         'DOC_API_URL': settings.DOC_API_URL,
         'APPLICATION_DETAILS': settings.APPLICATION_DETAILS,
+        'MSPROTOCOL': 'http',
+        'APIPROTOCOL': 'http',
     }
-                  
+
+    f hasattr(request, 'account'):
+        account = request.account
+        msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
+        apiprotocol = 'https' if account.get_preference('account.api.https').lower() == 'true' else 'http'
+        my_settings['MSPROTOCOL'] = msprotocol
+        my_settings['APIPROTOCOL'] = apiprotocol
+        
     d['settings'] = my_settings
     d['preference'] = request.preferences
     if hasattr(request, 'stats'):

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -17,7 +17,7 @@ def request_context(request):
         'APIPROTOCOL': 'http',
     }
 
-    f hasattr(request, 'account'):
+    if hasattr(request, 'account'):
         account = request.account
         msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
         apiprotocol = 'https' if account.get_preference('account.api.https').lower() == 'true' else 'http'

--- a/core/http.py
+++ b/core/http.py
@@ -59,8 +59,10 @@ def add_domains_to_permalinks(resources):
     for resource in resources:
         account_id = resource['account_id']
         if r.has_key(account_id):
+            account = Account.objects.get(pk=account_id)
+            msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
             account_domain = r[account_id]['account.domain']
-            resource['permalink'] = 'http://' + account_domain + resource['permalink']
+            resource['permalink'] = msprotocol + '://' + account_domain + resource['permalink']
             resource['account_name'] = r[account_id]['account.name']
 
 def get_file_type_from_extension(extension):

--- a/core/http.py
+++ b/core/http.py
@@ -5,6 +5,7 @@ from django.db.models import Q
 from core.choices import (SourceImplementationChoices, 
     SOURCE_IMPLEMENTATION_EXTENSION_CHOICES,
     SOURCE_IMPLEMENTATION_MIMETYPE_CHOICES)
+from core.models import Account
 
 class JSONHttpResponse(HttpResponse):
     """ A custom HttpResponse that handles the headers for our JSON responses """
@@ -18,12 +19,10 @@ def get_domain_with_protocol(app, protocol = 'http'):
     return protocol + '://' + settings.DOMAINS[app]
 
 def get_domain(account_id):
-    from core.models import Preference
-    try:
-        account_domain = Preference.objects.values('value').get(key='account.domain', account = account_id)['value']
-        account_domain = 'http://' + account_domain
-    except Preference.DoesNotExist:
-        account_domain = get_domain_with_protocol('microsites')
+    account = Account.objects.get(pk=account_id)
+    protocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
+    account_domain = account.get_preference('account.domain')
+    account_domain = '{}://{}'.format(protocol, account_domain)
     return account_domain
 
 def get_domain_by_request(request, default_domain = ''):

--- a/core/js/plugins/jquery-file-upload/basic-plus.html
+++ b/core/js/plugins/jquery-file-upload/basic-plus.html
@@ -100,9 +100,9 @@
 <!-- The jQuery UI widget factory, can be omitted if jQuery UI is already included -->
 <script src="js/vendor/jquery.ui.widget.js"></script>
 <!-- The Load Image plugin is included for the preview images and image resizing functionality -->
-<script src="http://blueimp.github.io/JavaScript-Load-Image/js/load-image.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.min.js"></script>
 <!-- The Canvas to Blob plugin is included for image resizing functionality -->
-<script src="http://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js"></script>
 <!-- Bootstrap JS is not required, but included for the responsive demo navigation -->
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
 <!-- The Iframe Transport is required for browsers without support for XHR file uploads -->

--- a/core/js/plugins/jquery-file-upload/test/index.html
+++ b/core/js/plugins/jquery-file-upload/test/index.html
@@ -147,9 +147,9 @@
 </script>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="../js/vendor/jquery.ui.widget.js"></script>
-<script src="http://blueimp.github.io/JavaScript-Templates/js/tmpl.min.js"></script>
-<script src="http://blueimp.github.io/JavaScript-Load-Image/js/load-image.min.js"></script>
-<script src="http://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Templates/js/tmpl.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Load-Image/js/load-image.min.js"></script>
+<script src="https://blueimp.github.io/JavaScript-Canvas-to-Blob/js/canvas-to-blob.min.js"></script>
 <script src="../js/jquery.iframe-transport.js"></script>
 <script src="../js/jquery.fileupload.js"></script>
 <script>window.testBasicWidget = $.blueimp.fileupload;</script>

--- a/core/js/plugins/markerclusterer.js
+++ b/core/js/plugins/markerclusterer.js
@@ -187,7 +187,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
  * @private
  */
 MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ =
-    'http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/' +
+    'https://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/' +
     'images/m';
 
 

--- a/core/manageDeveloper/views.py
+++ b/core/manageDeveloper/views.py
@@ -14,7 +14,8 @@ def filter(request):
                 'account.language', 'account.logo', 'account.header.uri', 'account.header.height',
                 'account.footer.uri', 'account.footer.height', 'account.enable.sharing']
         preferences.load(keys)
-        base_uri = 'http://' + preferences['account_domain']
+        msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
+        base_uri = msprotocol + '://' + preferences['account_domain']
         objs = DataStream.objects.filter(user__account_id=request.account.id, datastreamrevision__status=3)
         try:
             example_guid = objs[0].guid

--- a/core/templatetags/extra_tags.py
+++ b/core/templatetags/extra_tags.py
@@ -184,7 +184,8 @@ def account_logo(account, klass, roles):
     elif 'ao-free-user' in roles:
         return ''
     else:
-        account_domain = 'http://' + account_domain
+        msprotocol = 'https' if preferences['account.microsite.https'].lower() == 'true' else 'http'
+        account_domain = msprotocol + '://' + account_domain
     account_logo = account_logo and account_logo or '/static/workspace/images/_workspace/im_logoNotDefined.gif'
     account_name = preferences['account_name']
     img_string = '<a title="%s" href="%s"><img src="%s" alt="%s" title="%s" class="%s"/></a>' % (account_name, account_domain, account_logo, account_name, account_name, klass)

--- a/microsites/media/microsites/html/footer.html
+++ b/microsites/media/microsites/html/footer.html
@@ -11,7 +11,7 @@
 
     <title>Portal de Datos Públicos - Footer {{ settings.APPLICATION_DETAILS.name }}</title>
 
-    <link href="http://fonts.googleapis.com/css?family=Ubuntu:bold" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu:bold" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="assets/css/bootstrap.min.css">
     <link rel="stylesheet" href="assets/css/bootstrap-responsive.min.css">
     <link rel="stylesheet" href="assets/css/style.css">

--- a/microsites/media/microsites/html/header.html
+++ b/microsites/media/microsites/html/header.html
@@ -11,7 +11,7 @@
 
     <title>Portal de Datos Públicos - Header {{ settings.APPLICATION_DETAILS.name }}</title>
 
-    <link href="http://fonts.googleapis.com/css?family=Ubuntu:bold" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Ubuntu:bold" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="assets/css/bootstrap.min.css">
     <link rel="stylesheet" href="assets/css/bootstrap-responsive.min.css">
     <link rel="stylesheet" href="assets/css/style.css">

--- a/microsites/templates/base_microsites.html
+++ b/microsites/templates/base_microsites.html
@@ -103,7 +103,7 @@
 	    Configuration.chartSize = {"embed":{"width":"{{settings.DEFAULT_MICROSITE_CHART_SIZES.embed.width}}", "height":"{{settings.DEFAULT_MICROSITE_CHART_SIZES.embed.height}}" }, "normal":{"width":"{{settings.DEFAULT_MICROSITE_CHART_SIZES.normal.width}}", "height":"{{settings.DEFAULT_MICROSITE_CHART_SIZES.normal.height}}" }};
 
 	    {% if preferences.account_embed_powered_by %}
-	    Configuration.embedPoweredBy = ["http://{{preferences.account_domain}}","{{preferences.account_name}}"];
+	    Configuration.embedPoweredBy = ["{{settings.MSPROTOCOL}}://{{preferences.account_domain}}","{{preferences.account_name}}"];
   		{% else %}
   		Configuration.embedPoweredBy = ["{{ settings.APPLICATION_DETAILS.website }}","{{ settings.APPLICATION_DETAILS.name }}"];
   		{% endif %}

--- a/microsites/templates/loadHome/home_8.html
+++ b/microsites/templates/loadHome/home_8.html
@@ -9,8 +9,8 @@
 <script type="text/javascript" src="/js_microsites/loadHome/slider.js?id={{settings.VERSION_JS_CSS}}"></script>
 <script type="text/javascript" src="/js_core/base_modules/chart_manager/junarCharts.js?id={{settings.VERSION_JS_CSS}}"></script>    
 <script type="text/javascript" src="/js_core/plugins/markerclusterer.js?id={{settings.VERSION_JS_CSS}}"></script>
-<script type="text/javascript" src="http://www.google.com/jsapi"></script>
-<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
+<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false"></script>
 <script type="text/javascript">
   google.load('visualization', '1', {
     packages: ['corechart','geomap']

--- a/microsites/templates/loadHome/index.html
+++ b/microsites/templates/loadHome/index.html
@@ -56,7 +56,7 @@
 	              'packages':['corechart']
 	            }]
 	    }"></script>
-	<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=visualization"></script>
+	<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=visualization"></script>
 
 	<script type="text/javascript" src="{% static 'd3/d3.min.js' %}"></script>
 	<script type="text/javascript" src="{% static 'c3/c3.min.js' %}"></script>

--- a/microsites/templates/viewChart/embed.html
+++ b/microsites/templates/viewChart/embed.html
@@ -32,7 +32,7 @@
     {% block js_includes %}{% endblock %}
 
     <script type="text/javascript" src="http://www.google.com/jsapi"></script>
-    <script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=visualization"></script>
+    <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=visualization"></script>
     <script type="text/javascript" src="/js_core/plugins/multimarker.js?id={{settings.VERSION_JS_CSS}}"></script>
 
     <script type="text/javascript" src="/js_core/models.js?id={{settings.VERSION_JS_CSS}}"></script>

--- a/microsites/templates/viewChart/index.html
+++ b/microsites/templates/viewChart/index.html
@@ -51,7 +51,7 @@
               'packages':['corechart']
             }]
     }"></script>
-<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?libraries=visualization"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?libraries=visualization"></script>
 
 
 <script type="text/javascript" src="/js_core/plugins/multimarker.js?id={{settings.VERSION_JS_CSS}}"></script>

--- a/microsites/templates/viewChart/index.html
+++ b/microsites/templates/viewChart/index.html
@@ -4,7 +4,7 @@
 {% block SEO %}
     <title>{{visualization_revision.title}} &middot; {{preferences.account_page_titles}}</title>
     <meta name="description" content="{{ visualization_revision.description }}" />
-    <link rel="canonical" href="http://{{ preferences.account_domain}}{{visualization_revision.visualization_id|permalink:"visualization"}}" />
+    <link rel="canonical" href="{{settings.MSPROTOCOL}}://{{ preferences.account_domain}}{{visualization_revision.visualization_id|permalink:"visualization"}}" />
 {% endblock %}
 
 {% if preferences.account_enable_sharing %} 
@@ -160,7 +160,7 @@ var viewVisualizationModel = {
     createdAt: "{{ visualization_revision.created_at|date:'F d, Y, h:i A'|capfirst }}",
     modifiedAt: "{{ visualization_revision.modified_at|date:'F d, Y, h:i A'|capfirst }}",
     lastPublishDate: "{{visualization_revision.last_published_date|date:'F d, Y, h:i A'|capfirst}}",
-    publicUrl: "http://{{ preferences.account_domain }}{{ visualization_revision.visualization_id|permalink:'visualization' }}",
+    publicUrl: "{{settings.MSPROTOCOL}}://{{ preferences.account_domain }}{{ visualization_revision.visualization_id|permalink:'visualization' }}",
     lastPublishRevisionId: "{{ visualization_revision.last_published_revision_id }}",
 
     // Validar si es necesario

--- a/microsites/templates/viewChart/sidebarAPI.html
+++ b/microsites/templates/viewChart/sidebarAPI.html
@@ -31,12 +31,12 @@
 				<h1>{% trans 'VIEWDS-API-EXAMPLES' %}</h1>
 			</header>
 			<p>{% trans 'VIEWDS-API-EXAMPLES-1' %}</p>
-			<code>http://{{preferences.account_api_domain}}/api/v2/visualizations/{{visualization.guid}}?auth_key=YOUR_API_KEY</code>
+			<code>{{settings.APIPROTOCOL}}://{{preferences.account_api_domain}}/api/v2/visualizations/{{visualization.guid}}?auth_key=YOUR_API_KEY</code>
 			<p>{% trans 'VIEWDS-API-EXAMPLES-2' %}</p>
-			<code>http://{{preferences.account_api_domain}}/api/v2/visualizations/{{visualization.guid}}?auth_key=YOUR_API_KEY&amp;output=json_array</code>
+			<code>{{settings.APIPROTOCOL}}://{{preferences.account_api_domain}}/api/v2/visualizations/{{visualization.guid}}?auth_key=YOUR_API_KEY&amp;output=json_array</code>
 			{% if datastream.parameters %}
 			<p>{% trans 'VIEWDS-API-EXAMPLES-3' %}</p>
-			<code>http://{{preferences.account_api_domain}}/api/v2/visualizations/{{visualization.guid}}?auth_key=YOUR_API_KEY&amp;pArgument0=VALUE</code>
+			<code>{{settings.APIPROTOCOL}}://{{preferences.account_api_domain}}/api/v2/visualizations/{{visualization.guid}}?auth_key=YOUR_API_KEY&amp;pArgument0=VALUE</code>
 			{% endif %}
 		</article>
 		{% endif %}

--- a/microsites/templates/viewDataStream/index.html
+++ b/microsites/templates/viewDataStream/index.html
@@ -4,7 +4,7 @@
 {% block SEO %}
 	<title>{{datastream.title}} &middot; {{preferences.account_page_titles}}</title>
 	<meta name="description" content="{{ datastream.description }}" />
-	<link rel="canonical" href="http://{{preferences.account_domain}}{{datastream.datastream_id|permalink:'datastream'}}" />
+	<link rel="canonical" href="{{settings.MSPROTOCOL}}://{{preferences.account_domain}}{{datastream.datastream_id|permalink:'datastream'}}" />
 {% endblock %}
 
 {% if preferences.account_enable_sharing %}
@@ -150,8 +150,8 @@ $(document).ready(function(){
     {% for parameter in datastream.parameters %}
     parameter{{forloop.counter0}}: {name: "{{parameter.name}}", value: "{{parameter.default}}"},
     {% endfor %}
-    permaLink: "http://{{preferences.account_domain}}{{datastream.datastream_id|permalink:'datastream'}}{%if url_query%}?{{url_query}}{%endif%}",
-    embedUrl: "http://{{preferences.account_domain}}{{ datastream.guid|embedlink:'datastream' }}?header_row=0&fixed_column=0{%if url_query%}&{{url_query}}{%endif%}" ,
+    permaLink: "{{settings.MSPROTOCOL}}://{{preferences.account_domain}}{{datastream.datastream_id|permalink:'datastream'}}{%if url_query%}?{{url_query}}{%endif%}",
+    embedUrl: "{{settings.MSPROTOCOL}}://{{preferences.account_domain}}{{ datastream.guid|embedlink:'datastream' }}?header_row=0&fixed_column=0{%if url_query%}&{{url_query}}{%endif%}" ,
     createdAt: "{{datastream.created_at|date:'c'}}",
     filter: "",
     exportCSVURL: "{% url 'datastreams-data' datastream.last_published_revision_id 'csv' %}",

--- a/microsites/templates/viewDataStream/sidebarAPI.html
+++ b/microsites/templates/viewDataStream/sidebarAPI.html
@@ -31,12 +31,12 @@
 				<h1>{% trans 'VIEWDS-API-EXAMPLES' %}</h1>
 			</header>
 			<p>{% trans 'VIEWDS-API-EXAMPLES-1' %}</p>
-			<code>http://{{preferences.account_api_domain}}/api/v2/datastreams/{{datastream.guid}}/data.json?auth_key=YOUR_API_KEY</code>
+			<code>{{settings.APIPROTOCOL}}://{{preferences.account_api_domain}}/api/v2/datastreams/{{datastream.guid}}/data.json?auth_key=YOUR_API_KEY</code>
 			<p>{% trans 'VIEWDS-API-EXAMPLES-2' %}</p>
-			<code>http://{{preferences.account_api_domain}}/api/v2/datastreams/{{datastream.guid}}/data.json?auth_key=YOUR_API_KEY&amp;output=json_array</code>
+			<code>{{settings.APIPROTOCOL}}://{{preferences.account_api_domain}}/api/v2/datastreams/{{datastream.guid}}/data.json?auth_key=YOUR_API_KEY&amp;output=json_array</code>
 			{% if datastream.parameters %}
 			<p>{% trans 'VIEWDS-API-EXAMPLES-3' %}</p>
-			<code>http://{{preferences.account_api_domain}}/api/v2/datastreams/{{datastream.guid}}/data.json?auth_key=YOUR_API_KEY&amp;pArgument0=VALUE</code>
+			<code>{{settings.APIPROTOCOL}}://{{preferences.account_api_domain}}/api/v2/datastreams/{{datastream.guid}}/data.json?auth_key=YOUR_API_KEY&amp;pArgument0=VALUE</code>
 			{% endif %}
 		</article>
 		{% endif %}

--- a/microsites/templates/viewDataset/dataTable.html
+++ b/microsites/templates/viewDataset/dataTable.html
@@ -48,7 +48,7 @@
                                 <p>{{ datastream_revision.datastreami18n__description }}</p>
                               <div class="api_example">
                                 <p>{% trans 'VIEWDS-API-EXAMPLES' %}</p>
-                                <p>http://{{preferences.account_api_domain}}/api/v2/datastreams/{{datastream_revision.datastream__guid}}/data.json?auth_key=YOUR_API_KEY</p>
+                                <p>{{settings.APIPROTOCOL}}://{{preferences.account_api_domain}}/api/v2/datastreams/{{datastream_revision.datastream__guid}}/data.json?auth_key=YOUR_API_KEY</p>
                               </div>
                             </i>
                           </td>
@@ -70,7 +70,7 @@
                                 <p>{{ visualizations_revision.visualizationi18n__description }}</p>
                               <div class="api_example">
                                 <p>{% trans 'VIEWDS-API-EXAMPLES' %}</p>
-                                <p>http://{{preferences.account_api_domain}}/api/v2/visualizations/{{visualizations_revision.visualization__guid}}?auth_key=YOUR_API_KEY</p>
+                                <p>{{settings.APIPROTOCOL}}://{{preferences.account_api_domain}}/api/v2/visualizations/{{visualizations_revision.visualization__guid}}?auth_key=YOUR_API_KEY</p>
                               </div>
                             </i>
                           </td>

--- a/microsites/templates/viewDataset/index.html
+++ b/microsites/templates/viewDataset/index.html
@@ -97,8 +97,8 @@ $(document).ready(function(){
     guid: "{{dataset.guid}}",
     type: "{{dataset.impl_type}}",
     source: "{{dataset.end_point|escapejs}}",
-    permaLink: "http://{{ preferences.account_domain }}{{ dataset.dataset_id|permalink:'dataset' }}{%if url_query%}?{{url_query}}{%endif%}",
-    embedUrl: "http://{{ dataset.embedUrl }}?header_row=0&fixed_column=0{%if url_query%}&{{url_query}}{%endif%}" ,
+    permaLink: "{{settings.MSPROTOCOL}}://{{ preferences.account_domain }}{{ dataset.dataset_id|permalink:'dataset' }}{%if url_query%}?{{url_query}}{%endif%}",
+    embedUrl: "{{settings.MSPROTOCOL}}://{{ dataset.embedUrl }}?header_row=0&fixed_column=0{%if url_query%}&{{url_query}}{%endif%}" ,
     createdAt: "{{dataset.created_at|date:'c'}}"
   });
 

--- a/microsites/viewChart/views.py
+++ b/microsites/viewChart/views.py
@@ -66,7 +66,8 @@ def embed(request, guid):
     """
     account = request.account
     preferences = request.preferences
-    base_uri = 'http://' + preferences['account_domain']
+    msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
+    base_uri = msprotocol + '://' + preferences['account_domain']
 
     try:
         visualization_revision = VisualizationDBDAO().get(

--- a/microsites/viewDataStream/views.py
+++ b/microsites/viewDataStream/views.py
@@ -40,7 +40,8 @@ def view(request, id, slug):
 def embed(request, guid):
     account = request.account
     preferences = request.preferences
-    base_uri = 'http://' + preferences['account_domain']
+    msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
+    base_uri = msprotocol + '://' + preferences['account_domain']
 
     try:
         datastream = DataStreamDBDAO().get(

--- a/salt/roots/salt/apps/datal/local_settings_base.py
+++ b/salt/roots/salt/apps/datal/local_settings_base.py
@@ -30,7 +30,7 @@ DOMAINS = {'api': '{{  pillar["application"]["settings"]["domains"]["api"] }}',
            'cdn': '{{  pillar["application"]["cdn"] }}',
 }
 
-WORKSPACE_URI = 'http://{{  pillar["application"]["settings"]["domains"]["workspace"] }}'
+WORKSPACE_URI = '{{pillar["application"]["settings"]["workspace_protocol"]}}://{{  pillar["application"]["settings"]["domains"]["workspace"] }}'
 
 EMAIL_HOST = '{{  pillar["email"]["host"] }}'
 EMAIL_HOST_USER = '{{  pillar["email"]["user"] }}'

--- a/workspace/manageDatasets/views.py
+++ b/workspace/manageDatasets/views.py
@@ -468,7 +468,9 @@ def change_status(request, dataset_revision_id=None):
 
         # Limpio un poco
         response['result'] = DatasetDBDAO().get(request.user.language, dataset_revision_id=dataset_revision_id)
-        response['result']['public_url'] = "http://" + request.preferences['account.domain'] + reverse('manageDatasets.view', urlconf='microsites.urls', 
+        account = request.account
+        msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
+        response['result']['public_url'] = msprotocol + "://" + request.preferences['account.domain'] + reverse('manageDatasets.view', urlconf='microsites.urls', 
             kwargs={'dataset_id': response['result']['dataset_id'], 'slug': '-'})
         response['result'].pop('datastreams')
         response['result'].pop('visualizations')

--- a/workspace/manageDataviews/views.py
+++ b/workspace/manageDataviews/views.py
@@ -372,7 +372,9 @@ def change_status(request, datastream_revision_id=None):
 
         # Limpio un poco
         response['result'] = DataStreamDBDAO().get(request.user.language, datastream_revision_id=datastream_revision_id)
-        response['result']['public_url'] = "http://" + request.preferences['account.domain'] + reverse('viewDataStream.view', urlconf='microsites.urls', 
+        account = request.account
+        msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
+        response['result']['public_url'] = msprotocol + "://" + request.preferences['account.domain'] + reverse('viewDataStream.view', urlconf='microsites.urls', 
             kwargs={'id': response['result']['datastream_id'], 'slug': '-'})
         response['result'].pop('parameters')
         response['result'].pop('tags')

--- a/workspace/manageVisualizations/views.py
+++ b/workspace/manageVisualizations/views.py
@@ -211,7 +211,9 @@ def change_status(request, visualization_revision_id=None):
 
         # Limpio un poco
         response['result'] = VisualizationDBDAO().get(request.user.language, visualization_revision_id=visualization_revision_id)
-        response['result']['public_url'] = "http://" + request.preferences['account.domain'] + reverse('chart_manager.view', urlconf='microsites.urls', 
+        account = request.account
+        msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
+        response['result']['public_url'] = msprotocol + "://" + request.preferences['account.domain'] + reverse('chart_manager.view', urlconf='microsites.urls', 
             kwargs={'id': response['result']['visualization_id'], 'slug': '-'})
         response['result'].pop('parameters')
         response['result'].pop('tags')

--- a/workspace/personalizeHome/views.py
+++ b/workspace/personalizeHome/views.py
@@ -69,7 +69,9 @@ def save(request):
                 'status': 'ok',
                 'messages': [ugettext('APP-PREFERENCES-SAVESUCCESSFULLY-TEXT')]}), content_type='application/json')
         else:
-            previewHome = 'http://'+preferences['account_domain']+'/home?preview=true'
+            account = request.account
+            msprotocol = 'https' if account.get_preference('account.microsite.https').lower() == 'true' else 'http'
+            previewHome = msprotocol + '://' + preferences['account_domain']+'/home?preview=true'
             preferences['account.preview'] = jsonContent
             return HttpResponse(json.dumps({'preview_home':previewHome}), content_type='application/json')
 

--- a/workspace/templates/base_workspace.html
+++ b/workspace/templates/base_workspace.html
@@ -9,7 +9,7 @@
 		<link href="{% sass_src 'core/styles/plugins/backgrid/backgrid-text-cell.min.css' %}" type="text/css" rel="stylesheet" media="screen"/>
 		<link href="{% sass_src 'core/styles/plugins/backgrid/backgrid-filter.min.css' %}" type="text/css" rel="stylesheet" media="screen"/>
 		{% endcompress %}
-		<link href='http://fonts.googleapis.com/css?family=Roboto:700,400' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Roboto:700,400' rel='stylesheet' type='text/css'>
 {% endblock %}
 
 {% block js_includes %}

--- a/workspace/templates/createVisualization/index.html
+++ b/workspace/templates/createVisualization/index.html
@@ -24,7 +24,7 @@
               'packages':['corechart']
             }]
     }"></script>
-<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=visualization"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=visualization"></script>
 
 
 <script type="text/javascript" src="{% static 'handsontable/dist/handsontable.full.js' %}"></script>

--- a/workspace/templates/viewDataStream/index.html
+++ b/workspace/templates/viewDataStream/index.html
@@ -111,7 +111,7 @@ $(document).ready(function(){
     createVizUrl: "{% url 'manageVisualizations.create' %}?datastream_revision_id={{datastream.datastream_revision_id}}",
     editUrl: "{% url 'manageDataviews.edit' %}/{{datastream.datastream_revision_id}}/",
     lastPublishDate: "{{datastream.last_published_date|date:'F d, Y, h:i A'|capfirst }}",
-    publicUrl: "http://{{preference.account_domain}}{{ datastream.datastream_id|permalink:'datastream' }}",
+    publicUrl: "{{settings.MSPROTOCOL}}://{{preference.account_domain}}{{ datastream.datastream_id|permalink:'datastream' }}",
     createdAt: "{{ datastream.created_at|date:'F d, Y, h:i A'|capfirst  }}",
     modifiedAt: "{{ datastream.modified_at|date:'F d, Y, h:i A'|capfirst  }}"
   });

--- a/workspace/templates/viewDataset/index.html
+++ b/workspace/templates/viewDataset/index.html
@@ -80,7 +80,7 @@ $(document).ready(function(){
     lastPublishRevisionId: "{{ dataset.last_published_revision_id }}",
     editUrl: "{% url 'manageDatasets.edit' %}/{{dataset.dataset_revision_id}}/",
     lastPublishDate: "{{dataset.last_published_date|date:'F d, Y, h:i A'|capfirst}}",
-    publicUrl: "http://{{preference.account_domain}}{{ dataset.dataset_id|permalink:'dataset' }}",
+    publicUrl: "{{settings.MSPROTOCOL}}://{{preference.account_domain}}{{ dataset.dataset_id|permalink:'dataset' }}",
     createdAt: "{{ dataset.created_at|date:'F d, Y, h:i A'|capfirst }}",
     modifiedAt: "{{ dataset.modified_at|date:'F d, Y, h:i A'|capfirst }}"
   });

--- a/workspace/templates/viewVisualization/index.html
+++ b/workspace/templates/viewVisualization/index.html
@@ -19,7 +19,7 @@
               'packages':['corechart']
             }]
     }"></script>
-<script type="text/javascript" src="http://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=visualization"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?sensor=false&amp;libraries=visualization"></script>
 
 <script type="text/javascript" src="{% static 'd3/d3.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'c3/c3.min.js' %}"></script>

--- a/workspace/templates/viewVisualization/index.html
+++ b/workspace/templates/viewVisualization/index.html
@@ -97,7 +97,7 @@ var chartModel = new charts.models.Chart({
     createdAt: "{{ visualization_revision.created_at|date:'F d, Y, h:i A'|capfirst }}",
     modifiedAt: "{{ visualization_revision.modified_at|date:'F d, Y, h:i A'|capfirst }}",
     lastPublishDate: "{{visualization_revision.last_published_date|date:'F d, Y, h:i A'|capfirst}}",
-    publicUrl: "http://{{preference.account_domain}}{{ visualization_revision.visualization_id|permalink:'visualization' }}",
+    publicUrl: "{{settings.MSPROTOCOL}}://{{preference.account_domain}}{{ visualization_revision.visualization_id|permalink:'visualization' }}",
     changeStatusUrl: "{% url 'manageVisualizations.change_status' visualization_revision.visualization_revision_id %}",
     lastPublishRevisionId: "{{ visualization_revision.last_published_revision_id }}",
     editUrl: "{% url 'manageVisualizations.edit' visualization_revision.last_revision_id %}",


### PR DESCRIPTION
Mediante nuevas preferencias el api y los micrositios deberian generar sus urls con HTTPS.
Se requiere tambien que todo el contenido estático se cargue con ese protocolo.
(Faltan agregar cambios a este PR, es una primera versión)